### PR TITLE
Improve README usage for long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,34 @@
+import os
+
 from setuptools import find_packages, setup
+
+
+def get_long_description():
+    readme = os.path.join(os.path.dirname(__file__), "README.md")
+    out = []
+
+    with open(readme, "rt") as f:
+        # Long description is the README but slightly tweaked:
+        # - drop the first line (header) as it's redundant on pypi
+        # - drop the unusable TOC (no anchors rendered on pypi)
+        lines = f.__iter__()
+        next(lines)
+        for line in lines:
+            if "<!--TOC-->" in line:
+                for toc_line in lines:
+                    if "<!--TOC-->" in toc_line:
+                        break
+            else:
+                out.append(line)
+
+    return "".join(out)
+
 
 setup(
     name="django-kobo-exporter",
     version="0.1.1",
     description="prometheus exporter for kobo hub",
-    long_description=open("README.md").read(),
+    long_description=get_long_description(),
     long_description_content_type="text/markdown",
     url="https://github.com/release-engineering/django-kobo-exporter",
     license="GPLv3",


### PR DESCRIPTION
Some components of the README don't render ideally on pypi, so
process it slightly.