### PR TITLE
Slow down pre-commit-ci updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,6 @@ repos:
     hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace
+
+ci:
+    autoupdate_schedule: quarterly


### PR DESCRIPTION
Default is too noisy. As these updates could presumably involve
reformatting the code, the least frequent option seems best.