### PR TITLE
ci: use tox from pip, not OS

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -19,8 +19,7 @@ jobs:
         with:
           python-version: 2.7
 
-      - name: Install pip
-        # note: tox installed via apt doesn't play well with old python
+      - name: Install tox
         run: pip install tox
 
       - name: Run Tox
@@ -36,8 +35,8 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install system dependencies
-        run: sudo apt-get install -y tox
+      - name: Install tox
+        run: pip install tox
 
       - name: Run Tox
         run: tox -e static,tests


### PR DESCRIPTION
It was intended to use python 3.9 in this test configuration.
Using tox as packaged by the OS does not accomplish that, as that tox
will instead use the system's python (3.8) which propagates through to
the testenv.

Drop the apt-get install of tox and go with pip all the way.

Should fix the failure observed at
https://github.com/release-engineering/django-kobo-exporter/pull/34.