### PR TITLE
Make it compatible with Django 4

### DIFF
--- a/kobo_exporter/django_compat.py
+++ b/kobo_exporter/django_compat.py
@@ -8,4 +8,10 @@ else:
         return list(args)
 
 
-__all__ = ["patterns"]
+try:
+    from django.urls import re_path
+except ImportError:  # pragma: no cover
+    from django.conf.urls import url as re_path
+
+
+__all__ = ["patterns", "re_path"]

--- a/kobo_exporter/urls.py
+++ b/kobo_exporter/urls.py
@@ -1,9 +1,7 @@
-from django.conf.urls import url
-
 from . import views
-from .django_compat import patterns
+from .django_compat import patterns, re_path
 
 urlpatterns = patterns(
     "",
-    url(r"^metrics/?$", views.metrics),
+    re_path(r"^metrics/?$", views.metrics),
 )

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 
-from kobo_exporter.django_compat import patterns
+from kobo_exporter.django_compat import patterns, re_path
 
 urlpatterns = patterns(
     "",
-    url(r"^kobo_exporter/", include("kobo_exporter.urls")),
+    re_path(r"^kobo_exporter/", include("kobo_exporter.urls")),
 )


### PR DESCRIPTION
Django 4.0 removed some functionality deprecated in earlier versions.
For this project, we need to cope with the removal of the
django.conf.urls.url() alias of django.urls.re_path().