### PR TITLE
chore: pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     - id: black
 
@@ -11,7 +11,7 @@ repos:
     - id: isort
 
 -   repo: https://github.com/frnmst/md-toc
-    rev: 8.1.0
+    rev: 8.1.2
     hooks:
     - id: md-toc
 


### PR DESCRIPTION
Do a manual `pre-commit autoupdate' to resolve an installation problem
with the earlier version of black.