### PR TITLE
Manually trigger pre-commit to skip a bad dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
 
 -   repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
     - id: black
 
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
     - id: isort
 
 -   repo: https://github.com/frnmst/md-toc
-    rev: 8.1.4
+    rev: 8.1.8
     hooks:
     - id: md-toc
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace


### PR DESCRIPTION
The previous autoupdated pre-commit PR[1] failed due to a bad dependency md-toc 8.1.7. This patch manually updated it to fix the error.

- [github.com/psf/black: 22.8.0 → 22.12.0](psf/black@22.8.0...22.12.0)
- https://github.com/pycqa/isort/: 5.10.1 → 5.11.4
- [github.com/frnmst/md-toc: 8.1.4 → 8.1.8](frnmst/md-toc@8.1.4...8.1.8)
- [github.com/pre-commit/pre-commit-hooks: v4.3.0 → v4.4.0](pre-commit/pre-commit-hooks@v4.3.0...v4.4.0)

[1] https://github.com/release-engineering/django-kobo-exporter/pull/92