### PR TITLE
Manual bump of pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     - id: black
 
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
     - id: isort
 

--- a/kobo_exporter/views.py
+++ b/kobo_exporter/views.py
@@ -84,7 +84,7 @@ def metrics_string(workers):
     ]
 
     for worker in workers:
-        for (metric, fn) in getters:
+        for metric, fn in getters:
             value = fn(worker)
             metric.labels(worker=worker).set(value)
 


### PR DESCRIPTION
Current versions of the hooks (particularly isort) seem not to work in pre-commit.ci as of today. Manually update to latest versions to fix the problem.