### PR TITLE
Add support for Python 3.12 [RHELDST-32894]

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -11,16 +11,25 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.12]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Install tox
         run: pip install tox
 
       - name: Run Tox
-        run: tox -e static,tests
+        run: |
+          if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
+            tox -e py39,static
+          elif [[ "${{ matrix.python-version }}" == "3.12" ]]; then
+            tox -e py312,static
+          fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,15 @@
 [tox]
-envlist = static,tests
+envlist = static, py39, py312
 
 [testenv]
 deps = -rtest-requirements.txt
 commands = py.test -v --cov=kobo_exporter --cov-fail-under=100 {posargs}
+
+[testenv:py39]
+basepython = python3.9
+
+[testenv:py312]
+basepython = python3.12
 
 [testenv:static]
 commands =


### PR DESCRIPTION
This commit update tox.ini and GitHub Actions workflow to include Python3.12.

Continue generating test-requirements.txt using Python3.9 to ensure maximum compatibility with higher Python version.