### PR TITLE
Remove dichn from codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @rbikar @dichn @zxiong
+*  @rbikar @zxiong


### PR DESCRIPTION
ChenDi mentioned that his GitHub account "dichn" was previously changed and appears to have lost the codeowner permission, so it should be removed for now.